### PR TITLE
Fix Homepage topics count

### DIFF
--- a/app/controllers/discourse_reports/homepages_controller.rb
+++ b/app/controllers/discourse_reports/homepages_controller.rb
@@ -36,7 +36,7 @@ module DiscourseReports
     def ranked_topics_query
       top_topics
         .select(<<-SQL).to_sql
-          topics.*, dense_rank() OVER (
+          topics.*, row_number() OVER (
             PARTITION BY topics.category_id
             ORDER BY top_topics.yearly_score DESC
           ) AS topic_rank


### PR DESCRIPTION
Change dense_rank window function to row_number for right topic count with same score. Other work good. We have problem with Process category on our staging environment.